### PR TITLE
Coerce value to string for comparison

### DIFF
--- a/src/transition/attr.js
+++ b/src/transition/attr.js
@@ -20,7 +20,7 @@ function attrConstant(name, interpolate, value1) {
       interpolate0;
   return function() {
     var value0 = this.getAttribute(name);
-    return value0 === value1 + '' ? null
+    return value0 === value1 ? null
         : value0 === value00 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value1);
   };
@@ -31,7 +31,7 @@ function attrConstantNS(fullname, interpolate, value1) {
       interpolate0;
   return function() {
     var value0 = this.getAttributeNS(fullname.space, fullname.local);
-    return value0 === value1 + '' ? null
+    return value0 === value1 ? null
         : value0 === value00 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value1);
   };
@@ -70,5 +70,5 @@ export default function(name, value) {
   return this.attrTween(name, typeof value === "function"
       ? (fullname.local ? attrFunctionNS : attrFunction)(fullname, i, tweenValue(this, "attr." + name, value))
       : value == null ? (fullname.local ? attrRemoveNS : attrRemove)(fullname)
-      : (fullname.local ? attrConstantNS : attrConstant)(fullname, i, value));
+      : (fullname.local ? attrConstantNS : attrConstant)(fullname, i, value + ''));
 }

--- a/src/transition/attr.js
+++ b/src/transition/attr.js
@@ -20,7 +20,7 @@ function attrConstant(name, interpolate, value1) {
       interpolate0;
   return function() {
     var value0 = this.getAttribute(name);
-    return value0 === value1 ? null
+    return value0 === value1 + '' ? null
         : value0 === value00 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value1);
   };
@@ -31,7 +31,7 @@ function attrConstantNS(fullname, interpolate, value1) {
       interpolate0;
   return function() {
     var value0 = this.getAttributeNS(fullname.space, fullname.local);
-    return value0 === value1 ? null
+    return value0 === value1 + '' ? null
         : value0 === value00 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value1);
   };

--- a/src/transition/attr.js
+++ b/src/transition/attr.js
@@ -70,5 +70,5 @@ export default function(name, value) {
   return this.attrTween(name, typeof value === "function"
       ? (fullname.local ? attrFunctionNS : attrFunction)(fullname, i, tweenValue(this, "attr." + name, value))
       : value == null ? (fullname.local ? attrRemoveNS : attrRemove)(fullname)
-      : (fullname.local ? attrConstantNS : attrConstant)(fullname, i, value + ''));
+      : (fullname.local ? attrConstantNS : attrConstant)(fullname, i, value + ""));
 }

--- a/src/transition/style.js
+++ b/src/transition/style.js
@@ -56,5 +56,5 @@ export default function(name, value, priority) {
           .on("end.style." + name, styleRemoveEnd(name))
       : this.styleTween(name, typeof value === "function"
           ? styleFunction(name, i, tweenValue(this, "style." + name, value))
-          : styleConstant(name, i, value), priority);
+          : styleConstant(name, i, value + ''), priority);
 }

--- a/src/transition/style.js
+++ b/src/transition/style.js
@@ -56,5 +56,5 @@ export default function(name, value, priority) {
           .on("end.style." + name, styleRemoveEnd(name))
       : this.styleTween(name, typeof value === "function"
           ? styleFunction(name, i, tweenValue(this, "style." + name, value))
-          : styleConstant(name, i, value + ''), priority);
+          : styleConstant(name, i, value + ""), priority);
 }


### PR DESCRIPTION
getAttribute will always return a string.  It looks like this was in there a few commits back.  Not sure on the syntax, but just wanted to point it out.  Could also use a template string in ES6 `${value1}`.