### PR TITLE
Start from the inline style value, if present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ This method is useful to specify a custom interpolator, such as one that underst
 
 <a name="transition_style" href="#transition_style">#</a> <i>transition</i>.<b>style</b>(<i>name</i>, <i>value</i>[, <i>priority</i>]) [<>](https://github.com/d3/d3-transition/blob/master/src/transition/style.js "Source")
 
-For each selected element, assigns the [style tween](#transition_styleTween) for the style with the specified *name* to the specified target *value* with the specified *priority*. The starting value of the tween is the style’s computed value when the transition starts. The target *value* may be specified either as a constant or a function. If a function, it is immediately evaluated for each selected element, in order, being passed the current datum `d` and index `i`, with the `this` context as the current DOM element.
+For each selected element, assigns the [style tween](#transition_styleTween) for the style with the specified *name* to the specified target *value* with the specified *priority*. The starting value of the tween is the style’s inline value if present, and otherwise its computed value, when the transition starts. The target *value* may be specified either as a constant or a function. If a function, it is immediately evaluated for each selected element, in order, being passed the current datum `d` and index `i`, with the `this` context as the current DOM element.
 
 If the target value is null, the style is removed when the transition starts. Otherwise, an interpolator is chosen based on the type of the target value, using the following algorithm:
 
@@ -273,7 +273,7 @@ Or to interpolate from the current fill to blue, like [*transition*.style](#tran
 
 ```js
 selection.styleTween("fill", function() {
-  return d3.interpolateRgb(getComputedStyle(this).getPropertyValue("fill"), "blue");
+  return d3.interpolateRgb(this.style.fill, "blue");
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -g d3-color:d3,d3-interpolate:d3,d3-ease:d3,d3-dispatch:d3,d3-selection:d3,d3-timer:d3 -n d3 -o build/d3-transition.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-transition.js -c -m -o build/d3-transition.min.js",
-    "postpublish": "VERSION=`node -e 'console.log(require(\"./package.json\").version)'`; git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-transition/build/d3-transition.js d3-transition.v1.js && cp ../d3-transition/build/d3-transition.min.js d3-transition.v1.min.js && git add d3-transition.v1.js d3-transition.v1.min.js && git commit -m \"d3-transition ${VERSION}\" && git push && cd - && zip -j build/d3-transition.zip -- LICENSE README.md build/d3-transition.js build/d3-transition.min.js"
+    "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-transition/build/d3-transition.js d3-transition.v1.js && cp ../d3-transition/build/d3-transition.min.js d3-transition.v1.min.js && git add d3-transition.v1.js d3-transition.v1.min.js && git commit -m \"d3-transition ${npm_package_version}\" && git push && cd - && zip -j build/d3-transition.zip -- LICENSE README.md build/d3-transition.js build/d3-transition.min.js"
   },
   "dependencies": {
     "d3-color": "1",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "eslint": "3",
     "package-preamble": "0.0",
-    "rollup": "0.36",
+    "rollup": "0.41",
     "jsdom": "9",
     "tape": "4",
     "uglify-js": "2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "d3-dispatch": "1",
     "d3-ease": "1",
     "d3-interpolate": "1",
-    "d3-selection": "1",
+    "d3-selection": "^1.1.0",
     "d3-timer": "1"
   },
   "devDependencies": {

--- a/src/transition/style.js
+++ b/src/transition/style.js
@@ -1,5 +1,5 @@
 import {interpolateTransformCss as interpolateTransform} from "d3-interpolate";
-import {window} from "d3-selection";
+import {style} from "d3-selection";
 import {tweenValue} from "./tween";
 import interpolate from "./interpolate";
 
@@ -8,9 +8,8 @@ function styleRemove(name, interpolate) {
       value10,
       interpolate0;
   return function() {
-    var style = window(this).getComputedStyle(this, null),
-        value0 = style.getPropertyValue(name),
-        value1 = (this.style.removeProperty(name), style.getPropertyValue(name));
+    var value0 = style(this, name),
+        value1 = (this.style.removeProperty(name), style(this, name));
     return value0 === value1 ? null
         : value0 === value00 && value1 === value10 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value10 = value1);
@@ -27,7 +26,7 @@ function styleConstant(name, interpolate, value1) {
   var value00,
       interpolate0;
   return function() {
-    var value0 = window(this).getComputedStyle(this, null).getPropertyValue(name);
+    var value0 = style(this, name);
     return value0 === value1 ? null
         : value0 === value00 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value1);
@@ -39,10 +38,9 @@ function styleFunction(name, interpolate, value) {
       value10,
       interpolate0;
   return function() {
-    var style = window(this).getComputedStyle(this, null),
-        value0 = style.getPropertyValue(name),
+    var value0 = style(this, name),
         value1 = value(this);
-    if (value1 == null) value1 = (this.style.removeProperty(name), style.getPropertyValue(name));
+    if (value1 == null) value1 = (this.style.removeProperty(name), style(this, name));
     return value0 === value1 ? null
         : value0 === value00 && value1 === value10 ? interpolate0
         : interpolate0 = interpolate(value00 = value0, value10 = value1);


### PR DESCRIPTION
Rather than always starting from the [computed style value](https://developer.mozilla.org/en-US/docs/Web/CSS/computed_value), [*transition*.style](https://github.com/d3/d3-transition/blob/master/README.md#transition_style) now favors starting from the inline style value if present, and only falls back to the computed value if an inline value is not present.

By avoiding the computing style value in the common case where an inline style is present, this approach is faster, but more importantly it is more predictable since a computed value can differ surprisingly from its inline value, such as when the inline value is specified as a percentage. Consider the following element as an example:

```html
<div style="position:absolute;left:10%;">Hello, world!</div>
```

Given the following transition:

```js
d3.select("div")
  .transition()
    .duration(2500)
    .style("left", "80%");
```

Without this proposed change, d3-transition transitions from the *computed* value of 96px to the ending value of 80%. And since [*transition*.style](https://github.com/d3/d3-transition/blob/master/README.md#transition_style) uses [d3.interpolateString](https://github.com/d3/d3-interpolate/blob/master/README.md#interpolateString) internally, and since d3.interpolateString only interpolates numbers embedded in strings and thus only applies the ending units (%), the resulting interpolator is equivalent to:

```js
d3.interpolateString("96%", "80%") // [sad trombone]
```

And hence rather than transitioning from the left side of the page to the right, the div jumps to the far right of the page at the start of the transition, and then slides a little bit to the left. Oops!

With this change, the starting value is 10% and the ending value is 80%: the user-specified value is used for both the starting and ending value. For a live demonstration:

https://bl.ocks.org/mbostock/5b8a95a69a01494d731cbc2752dfadf2

Related d3/d3-selection#120. Fixes #47.