### PR TITLE
strike interpolateNumber from transition docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ d3.select("body")
 
 Transitions support most selection methods (such as [*transition*.attr](#transition_attr) and [*transition*.style](#transition_style) in place of [*selection*.attr](https://github.com/d3/d3-selection#selection_attr) and [*selection*.style](https://github.com/d3/d3-selection#selection_style)), but not all methods are supported; for example, you must [append](https://github.com/d3/d3-selection#selection_append) elements or [bind data](https://github.com/d3/d3-selection#joining-data) before a transition starts. A [*transition*.remove](#transition_remove) operator is provided for convenient removal of elements when the transition ends.
 
-To compute intermediate state, transitions leverage a variety of [built-in interpolators](https://github.com/d3/d3-interpolate). [Colors](https://github.com/d3/d3-interpolate#interpolateRgb), [numbers](https://github.com/d3/d3-interpolate#interpolateNumber), and [transforms](https://github.com/d3/d3-interpolate#interpolateTransform) are automatically detected. [Strings](https://github.com/d3/d3-interpolate#interpolateString) with embedded numbers are also detected, as is common with many styles (such as padding or font sizes) and paths. To specify a custom interpolator, use [*transition*.attrTween](#transition_attrTween), [*transition*.styleTween](#transition_styleTween) or [*transition*.tween](#transition_tween).
+To compute intermediate state, transitions leverage a variety of [built-in interpolators](https://github.com/d3/d3-interpolate). [Colors](https://github.com/d3/d3-interpolate#interpolateRgb) and [transforms](https://github.com/d3/d3-interpolate#interpolateTransform) are automatically detected. [Strings](https://github.com/d3/d3-interpolate#interpolateString) with embedded numbers are also detected, as is common with many styles (such as padding or font sizes) and paths. To specify a custom interpolator, use [*transition*.attrTween](#transition_attrTween), [*transition*.styleTween](#transition_styleTween) or [*transition*.tween](#transition_tween).
 
 ## Installing
 
@@ -203,9 +203,8 @@ For each selected element, assigns the [attribute tween](#transition_attrTween) 
 
 If the target value is null, the attribute is removed when the transition starts. Otherwise, an interpolator is chosen based on the type of the target value, using the following algorithm:
 
-1. If *value* is a number, use [interpolateNumber](https://github.com/d3/d3-interpolate#interpolateNumber).
-2. If *value* is a [color](https://github.com/d3/d3-color#color) or a string coercible to a color, use [interpolateRgb](https://github.com/d3/d3-interpolate#interpolateRgb).
-3. Use [interpolateString](https://github.com/d3/d3-interpolate#interpolateString).
+1. If *value* is a [color](https://github.com/d3/d3-color#color) or a string coercible to a color, use [interpolateRgb](https://github.com/d3/d3-interpolate#interpolateRgb).
+2. Use [interpolateString](https://github.com/d3/d3-interpolate#interpolateString).
 
 To apply a different interpolator, use [*transition*.attrTween](#transition_attrTween).
 
@@ -249,9 +248,8 @@ For each selected element, assigns the [style tween](#transition_styleTween) for
 
 If the target value is null, the style is removed when the transition starts. Otherwise, an interpolator is chosen based on the type of the target value, using the following algorithm:
 
-1. If *value* is a number, use [interpolateNumber](https://github.com/d3/d3-interpolate#interpolateNumber).
-2. If *value* is a [color](https://github.com/d3/d3-color#color) or a string coercible to a color, use [interpolateRgb](https://github.com/d3/d3-interpolate#interpolateRgb).
-3. Use [interpolateString](https://github.com/d3/d3-interpolate#interpolateString).
+1. If *value* is a [color](https://github.com/d3/d3-color#color) or a string coercible to a color, use [interpolateRgb](https://github.com/d3/d3-interpolate#interpolateRgb).
+2. Use [interpolateString](https://github.com/d3/d3-interpolate#interpolateString).
 
 To apply a different interpolator, use [*transition*.styleTween](#transition_styleTween).
 


### PR DESCRIPTION
per #67, it looks like `interpolateNumber` is never invoked, because all values are coerced to string first.

The proposal is to bring the documentation in sync with the implementation.

If this proposal is correct, then the first case could probably be dropped from `src/transition/interpolate.js`

Background: I want to understand why the behavior of some transitions changed when porting dc.js from d3v3 to d3v4. Previously if an attribute was not set on enter but was set in the transition, it took the final value with no animation. Now it starts from zero.

It's our bug and we need to fix it. We were relying on undefined behavior and it's better to be explicit about where you transition _from_. But, I still want to understand what changed.  

I found this SO question:
https://stackoverflow.com/questions/47339762/what-attributes-does-d3-transition-change

Which referenced this comment: https://github.com/d3/d3-transition/pull/67#issuecomment-345290841

I'm not sure if this change in implementation explains the change in observed behavior, but as noted, it's not a real problem.

_(edited for clarity)_