### PR TITLE
Fix regex bug in IE where parseTypenames didn't always work properly

### DIFF
--- a/src/transition/on.js
+++ b/src/transition/on.js
@@ -1,7 +1,7 @@
 import {get, set, init} from "./schedule.js";
 
 function start(name) {
-  return (name + "").trim().split(/^|\s+/).every(function(t) {
+  return (name + "").trim().split(/\s+/).filter(function(t) { return t; }).every(function(t) {
     var i = t.indexOf(".");
     if (i >= 0) t = t.slice(0, i);
     return !t || t === "start";


### PR DESCRIPTION
Same issue/fix as here: https://github.com/d3/d3-dispatch/pull/23